### PR TITLE
 Implementar endpoint Explore para dev/mentor

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -43,6 +43,7 @@ export function makeAuthController(authService: AuthService): AuthController {
         res
           .cookie('accessToken', tokens.accessToken, getCookieOptions(req))
           .cookie('idToken', tokens.idToken, getCookieOptions(req))
+          .cookie('refreshToken', tokens.refreshToken, getCookieOptions(req))
           .json({ message: 'Login realizado com sucesso.' })
       } catch (err: unknown) {
         const message = err instanceof AppError ? String(err.message) : 'Erro ao fazer login.'
@@ -66,7 +67,8 @@ export function makeAuthController(authService: AuthService): AuthController {
     },
 
     async refreshTokens(req: Request, res: Response) {
-      const { refreshToken } = req.body
+      const refreshToken = req.cookies.refreshToken || req.headers.authorization?.split(' ')[1]
+      console.log('Refresh tokens', refreshToken)
 
       try {
         const tokens = await authService.refreshTokens(refreshToken)
@@ -74,6 +76,7 @@ export function makeAuthController(authService: AuthService): AuthController {
         res
           .cookie('accessToken', tokens.accessToken, getCookieOptions(req))
           .cookie('idToken', tokens.idToken, getCookieOptions(req))
+          .cookie('refreshToken', tokens.refreshToken, getCookieOptions(req))
           .json({ message: 'Tokens atualizados com sucesso.' })
       } catch (err: unknown) {
         const message =

--- a/src/controllers/project.controller.test.ts
+++ b/src/controllers/project.controller.test.ts
@@ -3,19 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Project } from '@/models/domain/project'
 import { FakeProjectRepository } from '@/repositories/fake-project.repository'
-import { FakeUserRepository } from '@/repositories/fake-user.repository'
+import { FakeDatabase, FakeUserRepository } from '@/repositories/fake-user.repository'
 import { ProjectService } from '@/services/project.service'
 import { UserService } from '@/services/user.service'
 import { createFakeProjectInfo, createFakeUser, expectUuid } from '@/testes/helper'
 import { createMockResponse } from '@/testes/response'
 import { makeProjectController } from './project.controller'
-import { FakeProjectParticipantRepository } from '@/repositories/fake-project-participant.repository'
 
-const participantRepository = new FakeProjectParticipantRepository()
-const userRepository = new FakeUserRepository()
+const mockDB = new FakeDatabase()
+const userRepository = new FakeUserRepository(mockDB)
 const userService = new UserService(userRepository)
-const projectRepository = new FakeProjectRepository()
-const projectService = new ProjectService(projectRepository, participantRepository, userRepository)
+const projectRepository = new FakeProjectRepository(mockDB)
+const projectService = new ProjectService(projectRepository)
 const controller = makeProjectController(projectService, userService)
 
 const admin = createFakeUser('admin')

--- a/src/controllers/user.controller.test.ts
+++ b/src/controllers/user.controller.test.ts
@@ -1,4 +1,4 @@
-import { FakeUserRepository } from '@/repositories/fake-user.repository'
+import { FakeDatabase, FakeUserRepository } from '@/repositories/fake-user.repository'
 import { FakeEmailService } from '@/services/email/fake-email.service'
 import { UserService } from '@/services/user.service'
 import { makeUserController } from './user.controller'
@@ -8,7 +8,8 @@ import { createMockResponse } from '@/testes/response'
 import { Request } from 'express'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const userRepository = new FakeUserRepository()
+const mockDB = new FakeDatabase()
+const userRepository = new FakeUserRepository(mockDB)
 const userService = new UserService(userRepository)
 const fakeEmailService = new FakeEmailService()
 const controller = makeUserController(userService, fakeEmailService)

--- a/src/docs/project.openapi.ts
+++ b/src/docs/project.openapi.ts
@@ -213,6 +213,40 @@ export function registerProjectDocs() {
   })
 
   registry.registerPath({
+    method: 'get',
+    path: '/projects/explore',
+    tags: ['Project'],
+    description:
+      'Lista dos projetos em que o usuário autenticado (dev ou mentor) não está participando, mas consegue se candidatar.',
+    request: {
+      query: ProjectsListOwnQuerySchema,
+    },
+    responses: {
+      200: {
+        description: 'Projetos da empresa',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                projects: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Project' },
+                },
+                total: { type: 'number' },
+                page: { type: 'number' },
+                limit: { type: 'number' },
+              },
+            },
+          },
+        },
+      },
+      401: { description: 'Usuário não autenticado' },
+      403: { description: 'Acesso permitido apenas para empresas' },
+    },
+  })
+
+  registry.registerPath({
     method: 'post',
     path: '/projects/{id}/feedback',
     tags: ['Project'],

--- a/src/initDependecies.ts
+++ b/src/initDependecies.ts
@@ -2,7 +2,6 @@ import { getDb } from './config/drizzle'
 import { makeAuthController } from './controllers/auth.controller'
 import { makeProjectController } from './controllers/project.controller'
 import { makeUserController } from './controllers/user.controller'
-import { DrizzleProjectParticipantRepository } from './repositories/project-participant.repository'
 import { DrizzleProjectRepository } from './repositories/project.repository'
 import { DrizzleUserRepository } from './repositories/user.repository'
 import { makeAuthService } from './services/auth/make-auth-service'
@@ -17,13 +16,8 @@ export async function initDependencies() {
   const userRepository = new DrizzleUserRepository(db)
   const userService = new UserService(userRepository)
   const userController = makeUserController(userService, emailService)
-  const participantRepository = new DrizzleProjectParticipantRepository(db)
   const projectRepository = new DrizzleProjectRepository(db)
-  const projectService = new ProjectService(
-    projectRepository,
-    participantRepository,
-    userRepository
-  )
+  const projectService = new ProjectService(projectRepository)
   const projectController = makeProjectController(projectService, userService)
   const authService = await makeAuthService()
   const authController = makeAuthController(authService)

--- a/src/models/dto/feedback/feedback.dto.ts
+++ b/src/models/dto/feedback/feedback.dto.ts
@@ -1,12 +1,14 @@
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi'
 import { z } from 'zod'
 
+import { USER_ROLES } from '@/constants/user'
+
 extendZodWithOpenApi(z)
 
 export const FeedbackUserSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  role: z.enum(['admin', 'mentor', 'dev', 'company']), // opcional se quiser mostrar
+  role: z.enum(USER_ROLES),
 })
 
 export const FeedbackSchema = z.object({

--- a/src/repositories/fake-project-participant.repository.ts
+++ b/src/repositories/fake-project-participant.repository.ts
@@ -1,20 +1,17 @@
 import { ProjectParticipant } from '@/models/schema/project-participants'
+import { FakeDatabase } from './fake-user.repository'
 import { ProjectParticipantRepository } from './project-participant.repository'
 
 export class FakeProjectParticipantRepository implements ProjectParticipantRepository {
-  private db: ProjectParticipant[]
-
-  constructor() {
-    this.db = []
-  }
+  constructor(private readonly db: FakeDatabase) {}
 
   async create(application: ProjectParticipant): Promise<ProjectParticipant> {
-    await this.db.push(application)
+    await this.db.participants.push(application)
     return application
   }
 
   async getByProjectId(id: string): Promise<ProjectParticipant[] | null> {
-    const applications = this.db.filter((application) => application.projectId === id)
+    const applications = this.db.participants.filter((application) => application.projectId === id)
     return applications
   }
 }

--- a/src/repositories/fake-user.repository.ts
+++ b/src/repositories/fake-user.repository.ts
@@ -1,41 +1,53 @@
+import { Project } from '@/models/domain/project'
 import { User } from '@/models/domain/user'
-import { UserRepository } from './user.repository'
 import { ListUsersQueryType } from '@/models/dto/user/list.dto'
+import { ProjectParticipant } from '@/models/schema/project-participants'
+import { UserRepository } from './user.repository'
+
+export class FakeDatabase {
+  users: User[] = []
+  projects: Project[] = []
+  participants: ProjectParticipant[] = []
+
+  clear() {
+    this.users = []
+    this.projects = []
+    this.participants = []
+  }
+}
 
 export class FakeUserRepository implements UserRepository {
-  db: User[] = []
-
-  constructor() {
-    this.db = []
-  }
+  constructor(private readonly db: FakeDatabase) {}
 
   async create(user: User): Promise<User> {
-    this.db.push(user)
+    this.db.users.push(user)
     return user
   }
 
   async getById(id: string): Promise<User | null> {
-    const [user] = await this.db.filter((user: User) => user.id === id)
+    const [user] = await this.db.users.filter((user: User) => user.id === id)
     return user ? new User(user) : null
   }
 
   async getBySub(sub: string): Promise<User | null> {
-    const [user] = await this.db.filter((user: User) => user.sub === sub)
+    const [user] = await this.db.users.filter((user: User) => user.sub === sub)
     return user ? new User(user) : null
   }
 
   async getByEmail(email: string): Promise<User | null> {
-    const [user] = await this.db.filter((user: User) => user.email === email)
+    const [user] = await this.db.users.filter((user: User) => user.email === email)
     return user ? new User(user) : null
   }
 
   async getByEmailOrSub(email: string, sub: string): Promise<User | null> {
-    const [user] = await this.db.filter((user: User) => user.email === email || user.sub === sub)
+    const [user] = await this.db.users.filter(
+      (user: User) => user.email === email || user.sub === sub
+    )
     return user ? new User(user) : null
   }
 
   async findAllWithFilters(query: ListUsersQueryType): Promise<{ users: User[]; total: number }> {
-    const usersList = this.db.filter((user: User) => {
+    const usersList = this.db.users.filter((user: User) => {
       let match = true
       if (query.role) {
         match = match && user.role === query.role
@@ -53,6 +65,6 @@ export class FakeUserRepository implements UserRepository {
   }
 
   clean() {
-    this.db = []
+    this.db.users = []
   }
 }

--- a/src/routes/project.routes.ts
+++ b/src/routes/project.routes.ts
@@ -26,6 +26,7 @@ export function createProjectRoutes(
     controller.createProject
   )
   router.get('/', controller.listProjects)
+  router.get('/explore', controller.listExplorableProjects)
 
   router.get('/mine', controller.getUserProjects)
 

--- a/src/services/project.test.ts
+++ b/src/services/project.test.ts
@@ -1,18 +1,16 @@
 import { MAX_PROJECTS_PER_USER } from '@/constants/user'
 import { AppError } from '@/errors/AppErro'
 import { Project } from '@/models/domain/project'
-import { FakeProjectParticipantRepository } from '@/repositories/fake-project-participant.repository'
 import { FakeProjectRepository } from '@/repositories/fake-project.repository'
-import { FakeUserRepository } from '@/repositories/fake-user.repository'
+import { FakeDatabase } from '@/repositories/fake-user.repository'
 import { ProjectService } from '@/services/project.service'
 import { faker } from '@faker-js/faker'
 import { randomUUID } from 'node:crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const userRepository = new FakeUserRepository()
-const participantRepository = new FakeProjectParticipantRepository()
-const projectRespository = new FakeProjectRepository()
-const service = new ProjectService(projectRespository, participantRepository, userRepository)
+const mockDB = new FakeDatabase()
+const projectRespository = new FakeProjectRepository(mockDB)
+const service = new ProjectService(projectRespository)
 
 const data = {
   name: 'Projeto Teste',


### PR DESCRIPTION
### Descrição
Este PR implementa a nova rota GET /projects/explore, permitindo que usuários autenticados explorem projetos disponíveis para candidatura. O endpoint retorna apenas projetos:
- Com status = 'active'
- Com approvalStatus = 'approved'
- Nos quais o usuário ainda não participa e não é o criador

Closes #16
